### PR TITLE
fix: prevent `prevent necrobumping` in private discussions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
                 "color": "#fff"
             },
             "optional-dependencies": [
-                "flarum/tags"
+                "flarum/tags",
+                "fof/byobu"
             ]
         },
         "flagrow": {
@@ -58,7 +59,8 @@
     },
     "require-dev": {
         "flarum/phpstan": "*",
-        "flarum/tags": "*"
+        "flarum/tags": "*",
+        "fof/byobu": "*"
     },
     "scripts": {
         "analyse:phpstan": "phpstan analyse",

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -5,8 +5,12 @@ import ReplyComposer from 'flarum/forum/components/ReplyComposer';
 
 import NecrobumpingCheck from './components/NecrobumpingCheck';
 
-const isNecrobumping = (discussion) => {
+const isNecrobumping = (app, discussion) => {
   if (!discussion) return false;
+
+  if (app.initializers.has('fof-byobu') && discussion.isPrivateDiscussion()) {
+    return false;
+  }
 
   const days = discussion.attribute('fof-prevent-necrobumping');
   const lastPostedAt = discussion.lastPostedAt();
@@ -20,13 +24,13 @@ const isNecrobumping = (discussion) => {
 
 app.initializers.add('fof/prevent-necrobumping', () => {
   override(ReplyComposer.prototype, 'view', function (orig, vnode) {
-    this.attrs.disabled = this.attrs.disabled || (isNecrobumping(this.attrs.discussion) && !this.composer.fields.fofNecrobumping);
+    this.attrs.disabled = this.attrs.disabled || (isNecrobumping(app, this.attrs.discussion) && !this.composer.fields.fofNecrobumping);
 
     return orig(vnode);
   });
 
   extend(ReplyComposer.prototype, 'headerItems', function (items) {
-    const days = isNecrobumping(this.attrs.discussion);
+    const days = isNecrobumping(app, this.attrs.discussion);
 
     if (days) {
       items.add(

--- a/src/Listeners/ValidateNecrobumping.php
+++ b/src/Listeners/ValidateNecrobumping.php
@@ -14,6 +14,7 @@ namespace FoF\PreventNecrobumping\Listeners;
 use Carbon\Carbon;
 use Flarum\Post\Event\Saving;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Extension\ExtensionManager;
 use FoF\PreventNecrobumping\Util;
 use FoF\PreventNecrobumping\Validators\NecrobumpingPostValidator;
 use Illuminate\Support\Arr;
@@ -30,10 +31,16 @@ class ValidateNecrobumping
      */
     private $settings;
 
-    public function __construct(NecrobumpingPostValidator $validator, SettingsRepositoryInterface $settings)
+    /**
+     * @var ExtensionManager
+     */
+    protected $extensions;
+
+    public function __construct(NecrobumpingPostValidator $validator, SettingsRepositoryInterface $settings, ExtensionManager $extensions)
     {
         $this->validator = $validator;
         $this->settings = $settings;
+        $this->extensions = $extensions;
     }
 
     public function handle(Saving $event)
@@ -45,6 +52,7 @@ class ValidateNecrobumping
             return;
         }
 
+        if ($this->extensions->isEnabled('fof-byobu') && $discussion->is_private) {
             return;
         }
 

--- a/src/Listeners/ValidateNecrobumping.php
+++ b/src/Listeners/ValidateNecrobumping.php
@@ -38,12 +38,18 @@ class ValidateNecrobumping
 
     public function handle(Saving $event)
     {
-        if ($event->post->exists || $event->post->number === 1) {
+        $post = $event->post;
+        $discussion = $post->discussion;
+
+        if ($post->exists || $post->number === 1 || !$discussion) {
             return;
         }
 
-        $lastPostedAt = $event->post->discussion->last_posted_at;
-        $days = Util::getDays($this->settings, $event->post->discussion);
+            return;
+        }
+
+        $lastPostedAt = $discussion->last_posted_at;
+        $days = Util::getDays($this->settings, $discussion);
 
         if ($lastPostedAt && $days && $lastPostedAt->diffInDays(Carbon::now()) >= $days) {
             $this->validator->assertValid([

--- a/src/Listeners/ValidateNecrobumping.php
+++ b/src/Listeners/ValidateNecrobumping.php
@@ -12,9 +12,9 @@
 namespace FoF\PreventNecrobumping\Listeners;
 
 use Carbon\Carbon;
+use Flarum\Extension\ExtensionManager;
 use Flarum\Post\Event\Saving;
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\Extension\ExtensionManager;
 use FoF\PreventNecrobumping\Util;
 use FoF\PreventNecrobumping\Validators\NecrobumpingPostValidator;
 use Illuminate\Support\Arr;


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Alert popping up in private discussions

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
